### PR TITLE
Add extra arguments to the model checker

### DIFF
--- a/README.org
+++ b/README.org
@@ -76,12 +76,14 @@ file run with either ~C-c C-r~ or ~f10~
 + You can customize settings in the lustre-mode group.
 
 *** lustre-mode-comment-ind-level
-Is a setting that determins how many spaces to indent a comment.
+Is a setting that determines how many spaces to indent a comment.
 
 *** lustre-mode-executer-name
 Name of the lustre executor. Defaults to jkind. Assumes that jkind in in your path.
 
 [[http://loonwerks.com/tools/jkind.html][Jkind Loonwerks]]
+*** lustre-mode-extra-args
+List of extra arguments to be passed to the lustre executor. Should be a list of strings.
 * Changelog
 :PROPERTIES:
 :TOC:      :depth 0

--- a/lustre-mode.el
+++ b/lustre-mode.el
@@ -606,7 +606,7 @@
       (if (or (not compilation-ask-about-save)
 	      (y-or-n-p "Save file? "))
 	  (save-buffer)))
-  (let ((args (string-join (append lustre-mode-extra-args (list (buffer-file-name))))))
+  (let ((args (append lustre-mode-extra-args (list (buffer-file-name)))))
     (progn
       (delete-other-windows)
       ;; TODO let split horozontally
@@ -614,10 +614,10 @@
       (get-buffer-create "*run-lustre-mode*")
       (select-window (next-window))
       (switch-to-buffer "*run-lustre-mode*")
-      (start-process "lustre-mode-run"
-		     "*run-lustre-mode*"
-		     lustre-mode-executer-name
-		     args)
+      (apply 'start-process "lustre-mode-run"
+		         "*run-lustre-mode*"
+		         lustre-mode-executer-name
+		         args)
       (end-of-buffer)
       (select-window (next-window)))))
 

--- a/lustre-mode.el
+++ b/lustre-mode.el
@@ -96,6 +96,10 @@
 (defcustom lustre-mode-executer-name "jkind"
   "Name of the lustre executor"
   :group 'lustre-mode )
+
+(defcustom lustre-mode-extra-args nil
+  "Extra arguments to be passed to the lustre executor"
+  :group 'lustre-mode)
 ;;;; Variables
 
 
@@ -602,7 +606,7 @@
       (if (or (not compilation-ask-about-save)
 	      (y-or-n-p "Save file? "))
 	  (save-buffer)))
-  (let ((fichier (buffer-file-name)))
+  (let ((args (string-join (append lustre-mode-extra-args (list (buffer-file-name))))))
     (progn
       (delete-other-windows)
       ;; TODO let split horozontally
@@ -613,7 +617,7 @@
       (start-process "lustre-mode-run"
 		     "*run-lustre-mode*"
 		     lustre-mode-executer-name
-		     fichier)
+		     args)
       (end-of-buffer)
       (select-window (next-window)))))
 


### PR DESCRIPTION
Adds an extra customizable variable `lustre-mode-extra-args` which holds a list of the arguments to be passed to the lustre executor before passing the filename.